### PR TITLE
Support for Beaht Argument Transformers

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -11,6 +11,7 @@ default:
         - IntegratedExperts\BehatScreenshotExtension\Context\ScreenshotContext
         - FeatureContext
   extensions:
+    MinkFieldRandomizer\Extension: ~
     Behat\MinkExtension:
       goutte: ~
       files_path: "%paths.base%/tests/behat/fixtures"

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,7 @@
     },
     "autoload": {
         "psr-4": {
-            "MinkFieldRandomizer\\Filter\\": "src/MinkFieldRandomizer/Filter/",
-            "MinkFieldRandomizer\\Context\\": "src/MinkFieldRandomizer/Context/",
-            "MinkFieldRandomizer\\Model\\": "src/MinkFieldRandomizer/Model/",
-            "MinkFieldRandomizer\\Registry\\": "src/MinkFieldRandomizer/Registry/"
+            "MinkFieldRandomizer\\": "src/MinkFieldRandomizer/"
         }
     },
     "scripts": {

--- a/src/MinkFieldRandomizer/Extension.php
+++ b/src/MinkFieldRandomizer/Extension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MinkFieldRandomizer;
+
+use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Testwork\ServiceContainer\ServiceProcessor;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class Extension implements ExtensionInterface {
+
+    public function getConfigKey() {
+        return 'minkfieldrandomizer';
+    }
+
+    public function initialize(ExtensionManager $extensionManager) {
+
+    }
+
+    public function configure(ArrayNodeDefinition $builder) {
+
+    }
+
+    public function load(ContainerBuilder $container, array $config) {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__));
+        $loader->load('services.yml');
+    }
+
+    public function process(ContainerBuilder $container) {
+
+    }
+
+}

--- a/src/MinkFieldRandomizer/Transformation/Argument.php
+++ b/src/MinkFieldRandomizer/Transformation/Argument.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MinkFieldRandomizer\Transformation;
+
+use Behat\Behat\Definition\Call\DefinitionCall;
+use Behat\Behat\Transformation\Transformer\ArgumentTransformer;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use MinkFieldRandomizer\Context\FieldRandomizerTrait;
+
+class Argument implements ArgumentTransformer
+{
+
+    use FieldRandomizerTrait;
+
+    const SLOT_NAME_OPEN = '{';
+    const SLOT_NAME_CLOSE = '}';
+    const SLOT_NAME_REGEX = '#{([a-z0-9\(\)]\w*)}#i';
+
+    protected $context;
+    protected $matches;
+
+    /**
+     *
+     */
+    public function supportsDefinitionAndArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    {
+        return
+            (($argumentValue instanceof PyStringNode || is_scalar($argumentValue) || $argumentValue instanceof TableNode) &&
+                preg_match_all(self::SLOT_NAME_REGEX, serialize($argumentValue), $this->matches, PREG_SET_ORDER));
+    }
+
+    /**
+     *
+     */
+    public function transformArgument(DefinitionCall $definitionCall, $argumentIndex, $argumentValue)
+    {
+        // If this is a NodeTable we need to process every row / column separately.
+        if ($argumentValue instanceof TableNode) {
+            return $this->transformNodeTableArgument($definitionCall, $argumentIndex, $argumentValue);
+        }
+        $newArgumentValue = $this->frtFilterValue((string)$argumentValue);
+
+        if ($argumentValue instanceof PyStringNode) {
+            $newArgumentValue = explode("\n", $newArgumentValue);
+            $newArgumentValue = new PyStringNode($newArgumentValue, count($newArgumentValue));
+        }
+
+        return $newArgumentValue;
+    }
+
+    /**
+     * Transforms a whole argument table.
+     *
+     * @param TableNode $argumentValue
+     */
+    public function transformNodeTableArgument(DefinitionCall $definitionCall, $argumentIndex, TableNode $argumentValue)
+    {
+        $newTableData = $argumentValue->getTable();
+        foreach ($newTableData as $i => $row) {
+            foreach ($row as $c => $v) {
+                // Re-use the scalar replacement function.
+                $newTableData[$i][$c] = $this->transformArgument($definitionCall, $i, $v);
+            }
+        }
+
+        return new TableNode($newTableData);
+    }
+}

--- a/src/MinkFieldRandomizer/services.yml
+++ b/src/MinkFieldRandomizer/services.yml
@@ -1,0 +1,5 @@
+services:
+  transformation.argument_transformer.minkfieldrandomizer:
+    class: MinkFieldRandomizer\Transformation\Argument
+    tags:
+      -  { name: transformation.argument_transformer, priority: 100 }


### PR DESCRIPTION
Support for Beaht Argument Transformers: https://github.com/Behat/Behat/blob/master/src/Behat/Behat/Transformation/Transformer/ArgumentTransformer.php

If the extension is enabled in the behat.yml all arguments containing a randomizer string will be automagically transformed.