### PR TITLE
Update behat/mink-selenium2-driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "behat/behat": "~3.0",
         "behat/mink-extension": "~2.0",
         "behat/mink-goutte-driver": "1.2.x",
-        "behat/mink-selenium2-driver": "1.3.x"
+        "behat/mink-selenium2-driver": "^1.4"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5",


### PR DESCRIPTION
I can't update other composer-managed packages because behat/mink-selenium2-driver is stuck on 1.3 — Please update. Thanks!