### PR TITLE
fix: Fix argument parsing if params are present e.g. {RandomNumber(2,4)}

### DIFF
--- a/src/MinkFieldRandomizer/Transformation/Argument.php
+++ b/src/MinkFieldRandomizer/Transformation/Argument.php
@@ -15,7 +15,7 @@ class Argument implements ArgumentTransformer
 
     const SLOT_NAME_OPEN = '{';
     const SLOT_NAME_CLOSE = '}';
-    const SLOT_NAME_REGEX = '#{([a-z0-9\(\)\.-]\w*)}#i';
+    const SLOT_NAME_REGEX = '#{([a-z0-9\(\)\.,-]+\w*)}#i';
 
     protected $context;
     protected $matches;

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -6,6 +6,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\MinkContext;
 use MinkFieldRandomizer\Context\FieldRandomizerTrait;
 
@@ -52,6 +53,27 @@ class FeatureContext extends MinkContext implements Context
 
         if ($value1 !== $value2) {
             throw new \Exception(sprintf('Value from first field "%s" is not equal to value from second field "%s"', $value1, $value2));
+        }
+    }
+
+    /**
+     * Checks, that form field with specified id|name|label|value doesn't have a value matching anoter value.
+     * Example: Then the "username" field should not match "batman"
+     * Example: And the "username" field should not match "batman"
+     *
+     * @Then /^the "(?P<field>(?:[^"]|\\")*)" field should not match "(?P<value>(?:[^"]|\\")*)"$/
+     */
+    public function assertFieldNotMatches($field, $value)
+    {
+        $field = $this->fixStepArgument($field);
+        $value = $this->fixStepArgument($value);
+
+        $assertSession = $this->assertSession();
+        $node = $assertSession->fieldExists($field);
+        $actual = $node->getValue();
+        $message = sprintf('The field "%s" value "%s" has a match for "%s", but it should not.', $field, $actual, $value);
+        if (strpos($actual, $value) !== false) {
+            throw new ExpectationException($message, $this->getSession()->getDriver());
         }
     }
 }

--- a/tests/behat/features/form.feature
+++ b/tests/behat/features/form.feature
@@ -72,35 +72,88 @@ Feature: HTML screenshots
     When I fill in fields with provided table:
       | field1 | {RandomEmail} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomEmail}"
 
     When I fill in fields with provided table:
       | field1 | {RandomName} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomName}"
 
     When I fill in fields with provided table:
       | field1 | {RandomSurname} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomSurname}"
 
     When I fill in fields with provided table:
       | field1 | {RandomNumber} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomNumber}"
 
     When I fill in fields with provided table:
       | field1 | {RandomNumber(2,4)} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomNumber(2,4)}"
 
     When I fill in fields with provided table:
       | field1 | {RandomPhone} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomPhone}"
 
     When I fill in fields with provided table:
       | field1 | {RandomPhone(13)} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomPhone(13)}"
 
     When I fill in fields with provided table:
       | field1 | {RandomText} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomText}"
 
     When I fill in fields with provided table:
       | field1 | {RandomLoremIpsum} |
     Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomLoremIpsum}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomEmail}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomEmail}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomName}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomName}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomSurname}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomSurname}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomNumber}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomNumber}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomNumber(2,4)}"
+    Then the "field1" field should not match "RandomNumber(2,4)}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomPhone}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomPhone}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomPhone(13)}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomPhone(13)}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomText}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomText}"
+
+    When I fill in "field1" with ""
+    When I fill in "field1" with "{RandomLoremIpsum}"
+    Then the "field1" field should not contain ""
+    Then the "field1" field should not match "RandomLoremIpsum}"


### PR DESCRIPTION
Just stumbled over the fact that the argument parsing seems to fail if the argument contains params.
Example:
`When I fill in "field1" with "{RandomNumber(2,4)}"`
Will result in a value of "{RandomNumber(2,4)}" because `\Transformation\Argument::supportsDefinitionAndArgument()` will not recognize the argument as valid "function".
This is due to a to restrictive regexp in `\Transformation\Argument::SLOT_NAME_REGEX`.
This PR adjusts the related pattern and expands the test suite to catch this type of error.
If you run the test suite without the pattern adjustment it will fail, and it will completely pass once the pattern has been adjusted.